### PR TITLE
Fixed slashes of images paths in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,22 @@ See [security considerations](docs/security-considerations.md) for more details 
 
 But that is what we've managed to do for our needs using stock processors only. So you can do something similar or even better.
 
-![example-01.png](docs\examples\example-01.png)
-![example-02.png](docs\examples\example-02.png)
-![example-03.png](docs\examples\example-03.png)
-![example-04.png](docs\examples\example-04.png)
-![example-05.png](docs\examples\example-05.png)
-![example-06.png](docs\examples\example-06.png)
-![example-07.png](docs\examples\example-07.png)
-![example-08.png](docs\examples\example-08.png)
-![example-09.png](docs\examples\example-09.png)
-![example-10.png](docs\examples\example-10.png)
-![example-11.png](docs\examples\example-11.png)
-![example-12.png](docs\examples\example-12.png)
-![example-13.png](docs\examples\example-13.png)
-![example-14.png](docs\examples\example-14.png)
-![example-15.png](docs\examples\example-15.png)
-![example-16.png](docs\examples\example-16.png)
+![example-01.png](docs/examples/example-01.png)
+![example-02.png](docs/examples/example-02.png)
+![example-03.png](docs/examples/example-03.png)
+![example-04.png](docs/examples/example-04.png)
+![example-05.png](docs/examples/example-05.png)
+![example-06.png](docs/examples/example-06.png)
+![example-07.png](docs/examples/example-07.png)
+![example-08.png](docs/examples/example-08.png)
+![example-09.png](docs/examples/example-09.png)
+![example-10.png](docs/examples/example-10.png)
+![example-11.png](docs/examples/example-11.png)
+![example-12.png](docs/examples/example-12.png)
+![example-13.png](docs/examples/example-13.png)
+![example-14.png](docs/examples/example-14.png)
+![example-15.png](docs/examples/example-15.png)
+![example-16.png](docs/examples/example-16.png)
 
 ## Further reading
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ File.WriteAllBytes("test.png", captcha.Data);
 
 Run the program. If everything's fine, you'll find a file `test.png` next to the your program's executable:
 
-![test.png](getting-started\test.png "test.png")
+![test.png](getting-started/test.png "test.png")
 
 Not bad already!
 
@@ -52,14 +52,14 @@ There we see debug PNG files whose names contain layer index and name, processor
 
 First we see that on the vector layer `lines` some lines have appeared.
 
-![0_Vector00_lines_00_RandomLines_1.png](getting-started\0_Vector00_lines_00_RandomLines_1.png)
+![0_Vector00_lines_00_RandomLines_1.png](getting-started/0_Vector00_lines_00_RandomLines_1.png)
 
 Then those lines which all used to compose a single vector object are split into many objects.
 Debug renderer indicates this with different boundary lines: gray dashed lines denote objects, blue smaller-dashed lines denote individual paths within objects.
 
 We've split those lines into different objects because we want them to have different colors during rendering and `DrawVectorLayer` raster processor evaluates color on per-object basis.
 
-![0_Vector00_lines_01_SplitObjects_1.png](getting-started\0_Vector00_lines_01_SplitObjects_1.png)
+![0_Vector00_lines_01_SplitObjects_1.png](getting-started/0_Vector00_lines_01_SplitObjects_1.png)
 
 Then we proceed to the second vector layer `chars`.
 The set of processors within that layer is something quite common when rendering text-image CAPTCHAs.
@@ -68,34 +68,34 @@ So next processors do the arrangement.
 
 Initial characters somewhere left-topped:
 
-![0_Vector01_chars_00_CaptchaChars_1.png](getting-started\0_Vector01_chars_00_CaptchaChars_1.png)
+![0_Vector01_chars_00_CaptchaChars_1.png](getting-started/0_Vector01_chars_00_CaptchaChars_1.png)
 
 Snap to the left-top corner or the image:
 
-![0_Vector01_chars_01_SnapObjects_1.png](getting-started\0_Vector01_chars_01_SnapObjects_1.png)
+![0_Vector01_chars_01_SnapObjects_1.png](getting-started/0_Vector01_chars_01_SnapObjects_1.png)
 
 Move along Y axis to 10px:
 
-![0_Vector01_chars_02_MoveObjects_1.png](getting-started\0_Vector01_chars_02_MoveObjects_1.png)
+![0_Vector01_chars_02_MoveObjects_1.png](getting-started/0_Vector01_chars_02_MoveObjects_1.png)
 
 Resize proportionally to 60px height so they appear vertically centered:
 
-![0_Vector01_chars_03_ResizeObjects_1.png](getting-started\0_Vector01_chars_03_ResizeObjects_1.png)
+![0_Vector01_chars_03_ResizeObjects_1.png](getting-started/0_Vector01_chars_03_ResizeObjects_1.png)
 
 And finally distribute along X axis with the same 10px padding we've used for Y axis:
 
-![0_Vector01_chars_04_JustifyObjectsX_1.png](getting-started\0_Vector01_chars_04_JustifyObjectsX_1.png)
+![0_Vector01_chars_04_JustifyObjectsX_1.png](getting-started/0_Vector01_chars_04_JustifyObjectsX_1.png)
 
 Notice how the dots differ. Green dots are normal contour points, while orange are Bezier curves control points.
 
 Next are raster processors of the master layer. First of all the `Fill` processor does its job:
 
-![1_Raster00_master_00_Fill_1.png](getting-started\1_Raster00_master_00_Fill_1.png)
+![1_Raster00_master_00_Fill_1.png](getting-started/1_Raster00_master_00_Fill_1.png)
 
 Then the noise lines are drawn:
 
-![1_Raster00_master_01_DrawVectorLayer_1.png](getting-started\1_Raster00_master_01_DrawVectorLayer_1.png)
+![1_Raster00_master_01_DrawVectorLayer_1.png](getting-started/1_Raster00_master_01_DrawVectorLayer_1.png)
 
 And finally the CAPTCHA characters:
 
-![1_Raster00_master_02_DrawVectorLayer_1.png](getting-started\1_Raster00_master_02_DrawVectorLayer_1.png)
+![1_Raster00_master_02_DrawVectorLayer_1.png](getting-started/1_Raster00_master_02_DrawVectorLayer_1.png)


### PR DESCRIPTION
Used forward slashes in image paths instead of backward slashes.