### PR TITLE
configured variables in Directory.Build.props for proper versioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,12 @@
     <Company>Kaspersky Lab AO</Company>
     <Copyright>Copyright (c) Kaspersky Lab AO 2012-2025</Copyright>
     <Product>CaptchaMixer</Product>
-    <Version>1.0.0.0</Version>
-    <AssemblyVersion>$(Version)</AssemblyVersion>
-    <FileVersion>$(Version)</FileVersion>
+    <!-- Common version used both for DLLs and NuGet package -->
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
+    <!-- Set this for NuGet package to have a version suffix, e.g. "alpha1", "beta2", "rc" etc. -->
+    <VersionSuffix>beta1</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
Configured variables in Directory.Build.props for proper versioning both in DLLs and NuGet package.
Also set "beta1" suffix for NuGet package.